### PR TITLE
Disable PHY 2mbps (and rename)

### DIFF
--- a/config/totem.conf
+++ b/config/totem.conf
@@ -1,5 +1,8 @@
 CONFIG_ZMK_USB_LOGGING=n
-CONFIG_ZMK_KEYBOARD_NAME="KBHTotem"
+CONFIG_ZMK_KEYBOARD_NAME="Totem"
+
+# disable phy 2mbps (https://zmk.dev/docs/troubleshooting/connection-issues)
+CONFIG_BT_CTLR_PHY_2M=n
 
 CONFIG_ZMK_POINTING=y
 CONFIG_BT_CTLR_TX_PWR_PLUS_8=y


### PR DESCRIPTION
Trying to figure out why bluetooth connection won't work.

Shows up to connect on Mac, but fails. Won't even appear to connect with on iPad.