### PR TITLE
Fix board names for Zephyr 4.1 / HWMv2 migration

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 include:
-  - board: xiao_ble
+  - board: xiao_ble//zmk
     shield: totem_left
-  - board: xiao_ble
+  - board: xiao_ble//zmk
     shield: totem_right
-  - board: xiao_ble
+  - board: xiao_ble//zmk
     shield: settings_reset


### PR DESCRIPTION
## Fix board names for Zephyr 4.1 / HWMv2 migration

### Problem
After ZMK's upgrade to Zephyr 4.1, UF2 firmware files were not building correctly. The root cause is the migration to Hardware Model v2 (HWMv2), which requires a `//zmk` variant suffix on board identifiers.

### Solution
Updated `build.yaml` to use the new board naming convention:

```yaml
include:
  - board: xiao_ble//zmk
    shield: totem_left
  - board: xiao_ble//zmk
    shield: totem_right
  - board: xiao_ble//zmk
    shield: settings_reset
```

### Changes
- `build.yaml`: replaced `xiao_ble` with `xiao_ble//zmk` for all three build targets (left, right, settings_reset)