### PR TITLE
Port tomzbench Adv360 keymap to Totem

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,10 @@ bottom finger row), so everything that lived there now lives on a layer.
 3. **Alt lives near the pinky.** The user uses Alt-combos a lot and is used to
    Alt on the outer-pinky area. It's a hold on `Z`/`/`, not a layer-only mod.
 4. **Preserve Adv360 muscle memory** when relocating anything.
-5. **Brackets sit on the opposite-hand thumbs** from the layer hold.
+5. **Brackets sit on the free (opposite) hand's center+middle thumbs**; the middle
+   one doubles as the SYS cross-key via a tap-preferred hold-tap.
+6. **Easiest thumb key = center (by the gap).** Workhorses (space/enter) go there;
+   layer keys go on the middle (held, so a slightly harder spot is fine).
 
 ## User preferences (noted)
 - Fast typist — **misfire-free typing is the #1 priority**.
@@ -39,7 +42,10 @@ bottom finger row), so everything that lived there now lives on a layer.
 - `kp_slow_hold` — hold-tap, tap-preferred, 250ms. SPACE (rolls a lot → tap-biased).
 - `mo_fast_hold` — hold-tap (`&mo` + `&kp`), hold-preferred, 200ms. Layer thumbs (SYM/TAB, NUM/BSPC).
 - `lsft_sqt` / `rsft_dqt` — shift mod-morphs: hold = Shift, tap = `'` / `"` (morph yields the opposite quote when the other Shift is held).
-- `mo_slow_hold`, `grave_tilde` — defined, currently unused.
+- `mo_slow_hold` — hold-tap (`&mo` + `&kp`), tap-preferred, 250ms. Used for the
+  *middle* bracket keys on NUM/SYM (hold = cross-layer for SYS, tap = bracket) so the
+  bracket never misfires while the layer hold stays available.
+- `grave_tilde` — defined, currently unused.
 
 **config/totem.keymap** also defines:
 - `pmt` (pinky_mod_tap) — hold-tap, tap-preferred, 200ms → Alt on `Z` and `/`.
@@ -49,33 +55,43 @@ bottom finger row), so everything that lived there now lives on a layer.
 not bound to any key.** Available to map if the user wants them.
 
 ## Thumb cluster (shared by all layers)
-L→R: `LGUI/esc · LCTRL/spc · SYM/tab  ||  NUM/bspc · RCTRL/ent · RGUI/del`
-- Inner thumbs are the layer keys (SYM on left, NUM on right).
-- On **NUM**, the LEFT thumbs become `[` `]`.
-- On **SYM**, the RIGHT thumbs become `{` `}`.
+Positions per hand: **edge** (pinky side) · **middle** · **center** (by the gap).
+Center is the easiest/natural rest, so the workhorses live there.
+
+Base, L→R: `GUI/esc · SYM/tab · CTRL/space  ||  CTRL/enter · NUM/bspc · GUI/del`
+- **Center** = space (L) / enter (R), CTRL on the hold — easiest keys, most-tapped.
+- **Middle** = the layer keys (SYM left, NUM right). Held, not tapped, so fine.
+- **Edge** = GUI + esc/del (rare).
+- **SYS = squeeze both middle thumbs** (SYM + NUM) — symmetric.
+- Brackets: on **NUM**, left center+middle = `] [`→ reads `[ ]`; on **SYM**, right
+  center+middle = `{ }`. The *middle* bracket is a `mo_slow_hold` (hold = cross-layer
+  for SYS, tap = bracket); the *center* bracket overrides the layer-held space/enter
+  (unused there). Brackets get the two easiest keys AND SYS stays a symmetric squeeze.
 
 ## Layers
 ### BASE (0) — QWERTY
 Outer pinkies = shift morphs (tap `'`/`"`). `Z` and `/` = hold Alt / tap letter.
 
-### NUM (1) — hold right inner thumb
+### NUM (1) — hold right-MIDDLE thumb
 Numbers on the LEFT (type with the free hand). RIGHT: mods on the home row so
-`Ctrl+digit` etc. work, arrows on the row beneath them. `[ ]` on left thumbs.
+`Ctrl+digit` etc. work, arrows on the row beneath them. Left thumbs: `[` (middle,
+also holds SYM→SYS) + `]` (center).
 ```
 + 7 8 9 0      ·  ·   ·   ·   ·
 - 1 2 3 =      :  GUI CTL ALT  ·
 * 4 5 6 \      ·  ←   ↓   ↑    →
 ```
 
-### SYM (2) — hold left inner thumb
-Symbols on the RIGHT (1:1 from Adv360). Left hand transparent. `{ }` on right thumbs.
+### SYM (2) — hold left-MIDDLE thumb
+Symbols on the RIGHT (1:1 from Adv360). Left hand transparent. Right thumbs:
+`{` (center) + `}` (middle, also holds NUM→SYS).
 ```
 · · · · ·      ~ & * ( )
 · · · · ·      _ ! @ # +
 · · · · ·      ` $ % ^ |
 ```
 
-### SYS (3) — hold NUM + SYM together
+### SYS (3) — squeeze both middle thumbs (NUM + SYM)
 F-keys on the LEFT, **mirroring the NUM digit positions** (F1 where 1 is, … F11/F12
 in the `+`/`-` corners). BT + bootloader on the RIGHT.
 ```
@@ -88,11 +104,20 @@ F12 F1 F2 F3  ·     BTclr BT0  BT1  BT2  BT3
 GitHub Actions on the **`tomzbench` fork** (TomzBench/zmk-totem-config). Push the
 branch, download firmware from the Actions run. KBH guide:
 https://keyboard-hoarders.com/pages/guides-1
-`totem.conf`: 15-min sleep, pointing enabled, BT TX +8dB, ZMK Studio off.
+`totem.conf`: 15-min sleep, pointing enabled, BT TX +8dB, ZMK Studio on, split
+battery reporting on (both halves report to the host).
+
+**ZMK Studio gotcha (learned the hard way):** with `CONFIG_ZMK_STUDIO=y` the shield
+must use **physical layouts** — and ZMK's `USE_PHY_LAYOUTS` check requires
+`!DT_HAS_CHOSEN(zmk_matrix_transform)`. So the shield's `chosen` must **drop**
+`zmk,matrix_transform` and instead set `zmk,physical-layout = &totem_layout` (the
+layout node carries the `transform`). Build also needs `snippet: studio-rpc-usb-uart`
+on the left/central entry in `build.yaml`.
 
 ## Intentionally excluded (don't "add back" without asking)
 Physical number row, number-layer toggle/lock (`tog 1`), arrows on base,
-page-nav / home / end, output-toggle / soft-reset, German locale keys.
+page-nav / home / end, soft-reset (the `settings_reset` shield handles it),
+German locale keys. (Output toggle `OUT_TOG` *was* added later, on SYS.)
 `£` (POUND) from the source SYM was changed to `#` (HASH) for US.
 
 ## Editing tips

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,103 @@
+# KBH Totem — ZMK keymap (tomzbench layout)
+
+Design context for **modifying the keymap going forward**. The original port is
+done; this file is the reasoning + the user's preferences so future changes stay
+consistent. (If you're just here to edit keys: read "Design rules" and "Layers".)
+
+## What this is
+ZMK config for the KeyboardHoarders **Totem** — a 38-key split: 3×5 alphas + 3
+thumbs per hand, plus **one outer pinky per hand on row 3**. Board `xiao_ble`,
+shields `totem_left` / `totem_right` (+ `settings_reset`). The layout is ported
+from the user's Kinesis Advantage 360 Pro config ("tomzbench" keymap).
+
+Key budget: 30 alphas + 6 thumbs + 2 outer pinkies = 38. The Totem has ~28
+*fewer* keys than the Adv360 used (no number row, no outer symbol columns, no
+bottom finger row), so everything that lived there now lives on a layer.
+
+## Design rules (honor unless the user explicitly overrides)
+1. **Thumb mods, NOT home-row mods.** Mods live on thumbs + pinkies; the home
+   row stays pure letters. Reason: the user is a fast typist and home-row mods
+   misfire on rolls. *Do not reintroduce home-row mods without asking.*
+2. **No timing misfires; explicit beats clever.** Alpha keys that carry a mod
+   use `tap-preferred` so normal typing never triggers the hold.
+3. **Alt lives near the pinky.** The user uses Alt-combos a lot and is used to
+   Alt on the outer-pinky area. It's a hold on `Z`/`/`, not a layer-only mod.
+4. **Preserve Adv360 muscle memory** when relocating anything.
+5. **Brackets sit on the opposite-hand thumbs** from the layer hold.
+
+## User preferences (noted)
+- Fast typist — **misfire-free typing is the #1 priority**.
+- Uses Alt-combos often; wants Alt as a pinky **hold**.
+- Comfortable with **arrows below the home row**.
+- Doesn't lean on F-keys / nav — fine for them to be a layer-hold away.
+- **US layout** (German/locale keys from the source were dropped).
+- Prefers explicit, well-reasoned behaviors over dense tricks.
+
+## Behaviors
+**config/tomzbench.dtsi** (the hold-tap "flavors" + shift morphs):
+- `kp_fast_hold` — hold-tap, hold-preferred, 200ms. Decisive mod thumbs (GUI/CTRL/ENTER/DEL/ESC).
+- `kp_slow_hold` — hold-tap, tap-preferred, 250ms. SPACE (rolls a lot → tap-biased).
+- `mo_fast_hold` — hold-tap (`&mo` + `&kp`), hold-preferred, 200ms. Layer thumbs (SYM/TAB, NUM/BSPC).
+- `lsft_sqt` / `rsft_dqt` — shift mod-morphs: hold = Shift, tap = `'` / `"` (morph yields the opposite quote when the other Shift is held).
+- `mo_slow_hold`, `grave_tilde` — defined, currently unused.
+
+**config/totem.keymap** also defines:
+- `pmt` (pinky_mod_tap) — hold-tap, tap-preferred, 200ms → Alt on `Z` and `/`.
+- tri-layer `conditional_layers`: **NUM + SYM held → SYS**.
+
+**config/macros.dtsi** — Win/Mac shortcuts + bracket/quote macros. **Defined but
+not bound to any key.** Available to map if the user wants them.
+
+## Thumb cluster (shared by all layers)
+L→R: `LGUI/esc · LCTRL/spc · SYM/tab  ||  NUM/bspc · RCTRL/ent · RGUI/del`
+- Inner thumbs are the layer keys (SYM on left, NUM on right).
+- On **NUM**, the LEFT thumbs become `[` `]`.
+- On **SYM**, the RIGHT thumbs become `{` `}`.
+
+## Layers
+### BASE (0) — QWERTY
+Outer pinkies = shift morphs (tap `'`/`"`). `Z` and `/` = hold Alt / tap letter.
+
+### NUM (1) — hold right inner thumb
+Numbers on the LEFT (type with the free hand). RIGHT: mods on the home row so
+`Ctrl+digit` etc. work, arrows on the row beneath them. `[ ]` on left thumbs.
+```
++ 7 8 9 0      ·  ·   ·   ·   ·
+- 1 2 3 =      :  GUI CTL ALT  ·
+* 4 5 6 \      ·  ←   ↓   ↑    →
+```
+
+### SYM (2) — hold left inner thumb
+Symbols on the RIGHT (1:1 from Adv360). Left hand transparent. `{ }` on right thumbs.
+```
+· · · · ·      ~ & * ( )
+· · · · ·      _ ! @ # +
+· · · · ·      ` $ % ^ |
+```
+
+### SYS (3) — hold NUM + SYM together
+F-keys on the LEFT, **mirroring the NUM digit positions** (F1 where 1 is, … F11/F12
+in the `+`/`-` corners). BT + bootloader on the RIGHT.
+```
+F11 F7 F8 F9 F10    BOOT  ·    ·    ·    ·
+F12 F1 F2 F3  ·     BTclr BT0  BT1  BT2  BT3
+ ·  F4 F5 F6  ·     BT4 BTnxt  ·    ·    ·
+```
+
+## Build
+GitHub Actions on the **`tomzbench` fork** (TomzBench/zmk-totem-config). Push the
+branch, download firmware from the Actions run. KBH guide:
+https://keyboard-hoarders.com/pages/guides-1
+`totem.conf`: 15-min sleep, pointing enabled, BT TX +8dB, ZMK Studio off.
+
+## Intentionally excluded (don't "add back" without asking)
+Physical number row, number-layer toggle/lock (`tog 1`), arrows on base,
+page-nav / home / end, output-toggle / soft-reset, German locale keys.
+`£` (POUND) from the source SYM was changed to `#` (HASH) for US.
+
+## Editing tips
+- Each layer's `bindings` must be **exactly 38** entries in this order:
+  row1 (10) · row2 (10) · row3 (1 outer + 5 + 5 + 1 outer = 12) · thumbs (6).
+- Trust the `bindings = < … >`, then update the ASCII diagram to match.
+- Behaviors/macros are copied **in-tree** — the repo is self-contained (no
+  dependency on the external Adv360 repo anymore).

--- a/build.yaml
+++ b/build.yaml
@@ -1,6 +1,7 @@
 include:
   - board: xiao_ble//zmk
     shield: totem_left
+    snippet: studio-rpc-usb-uart
   - board: xiao_ble//zmk
     shield: totem_right
   - board: xiao_ble//zmk

--- a/config/boards/shields/totem/totem-layouts.dtsi
+++ b/config/boards/shields/totem/totem-layouts.dtsi
@@ -5,6 +5,7 @@ totem_layout: totem_layout{
     compatible = "zmk,physical-layout";
     display-name = "TOTEM Keyboard Layout";
     transform = <&default_transform>;
+    kscan = <&kscan0>;
     keys  //                     w   h    x    y     rot    rx    ry
     = <&key_physical_attrs 100 100   70  136 (-1000)   120   186>
     , <&key_physical_attrs 100 100  176   54  (-400)   226   104>

--- a/config/boards/shields/totem/totem.dtsi
+++ b/config/boards/shields/totem/totem.dtsi
@@ -10,6 +10,7 @@
     chosen {
         zmk,kscan = &kscan0;
         zmk,matrix_transform = &default_transform;
+        zmk,physical-layout = &totem_layout;
     };
 
     default_transform: keymap_transform_0 {

--- a/config/boards/shields/totem/totem.dtsi
+++ b/config/boards/shields/totem/totem.dtsi
@@ -9,7 +9,9 @@
 / {
     chosen {
         zmk,kscan = &kscan0;
-        zmk,matrix_transform = &default_transform;
+        /* No zmk,matrix_transform: ZMK Studio requires the transform to come
+           from the physical layout (totem_layout) instead. Keeping a chosen
+           matrix_transform makes USE_PHY_LAYOUTS false and fails the build. */
         zmk,physical-layout = &totem_layout;
     };
 

--- a/config/boards/shields/totem/totem.dtsi
+++ b/config/boards/shields/totem/totem.dtsi
@@ -33,7 +33,7 @@
         compatible = "zmk,kscan-gpio-matrix";
         label = "KSCAN";
         wakeup-source;
-        diode-direction = "col2row"; 
+        diode-direction = "col2row";
         row-gpios
             = <&xiao_d 0 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
             , <&xiao_d 1 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
@@ -42,3 +42,7 @@
             ;
     };
 };
+
+/* Physical layout — required by ZMK Studio. Ships with the shield but is
+   otherwise unused; references &default_transform defined above. */
+#include "totem-layouts.dtsi"

--- a/config/macros.dtsi
+++ b/config/macros.dtsi
@@ -1,0 +1,224 @@
+  macro_quotes: macro_quotes {
+    compatible = "zmk,behavior-macro";
+    label = "macro_quotes";
+    #binding-cells = <0>;
+    bindings = <&kp SQT>, <&kp SQT>, <&kp LEFT>;
+  };
+  macro_dquotes: macro_dquotes {
+    compatible = "zmk,behavior-macro";
+    label = "macro_dquotes";
+    #binding-cells = <0>;
+    bindings = <&kp DQT>, <&kp DQT>, <&kp LEFT>;
+  };
+  macro_braces: macro_braces {
+    compatible = "zmk,behavior-macro";
+    label = "macro_braces";
+    #binding-cells = <0>;
+    bindings = <&kp LBRC>, <&kp RBRC>, <&kp LEFT>;
+  };
+  macro_parens: macro_parens {
+    compatible = "zmk,behavior-macro";
+    label = "macro_parens";
+    #binding-cells = <0>;
+    bindings = <&kp LPAR>, <&kp RPAR>, <&kp LEFT>;
+  };
+  macro_brackets: macro_brackets {
+    compatible = "zmk,behavior-macro";
+    label = "macro_brackets";
+    #binding-cells = <0>;
+    bindings = <&kp LBKT>, <&kp RBKT>, <&kp LEFT>;
+  };
+  macro_kinesis: macro_kinesis {
+    compatible = "zmk,behavior-macro";
+    label = "macro_kinesis";
+    #binding-cells = <0>;
+    bindings = <&kp LS(K)>, <&kp I>, <&kp N>, <&kp E>, <&kp S>, <&kp I>, <&kp S>;
+  };
+  Win_Cut: Windows_Cut {
+    compatible = "zmk,behavior-macro";
+    #binding-cells = <0>;
+    bindings = <&kp LC(X)>;
+    display-name = "Windows Cut";
+  };
+
+  Win_Copy: Windows_Copy {
+    compatible = "zmk,behavior-macro";
+    #binding-cells = <0>;
+    bindings = <&kp LC(C)>;
+    display-name = "Windows Copy";
+  };
+
+  Win_Paste: Windows_Paste {
+    compatible = "zmk,behavior-macro";
+    #binding-cells = <0>;
+    bindings = <&kp LC(V)>;
+    display-name = "Windows Paste";
+  };
+
+  Win_Select_All: Windows_SelectAll {
+      compatible = "zmk,behavior-macro";
+      #binding-cells = <0>;
+      bindings = <&kp LC(A)>;
+      display-name = "Windows Select All";
+  };
+
+  Win_Undo: Windows_Undo {
+    compatible = "zmk,behavior-macro";
+    #binding-cells = <0>;
+    bindings = <&kp LC(Z)>;
+    display-name = "Windows Undo";
+  };
+
+  Win_Desktop: Win_Desk {
+    compatible = "zmk,behavior-macro";
+    #binding-cells = <0>;
+    bindings = <&kp LG(D)>;
+    display-name = "Windows Desktop";
+  };
+
+  Win_File_Explorer: Win_Explr {
+    compatible = "zmk,behavior-macro";
+    #binding-cells = <0>;
+    bindings = <&kp LG(E)>;
+    display-name = "Windows Explorer";
+  };
+
+  Win_Snip_Tool: Win_Snip {
+    compatible = "zmk,behavior-macro";
+    #binding-cells = <0>;
+    bindings = <&kp LS(LG(S))>;
+    display-name = "Windows Screen Snip";
+  };
+
+  Win_Show_All_Windows: Win_ShowAW {
+    compatible = "zmk,behavior-macro";
+    #binding-cells = <0>;
+    bindings = <&kp LG(TAB)>;
+    display-name = "Windows Show All Windows";
+  };
+
+  Mac_Cut: Mac_Cut {
+    compatible = "zmk,behavior-macro";
+    #binding-cells = <0>;
+    bindings = <&kp LG(X)>;
+    display-name = "Mac Cut";
+  };
+
+  Mac_Copy: Mac_Copy {
+    compatible = "zmk,behavior-macro";
+    #binding-cells = <0>;
+    bindings = <&kp LG(C)>;
+    display-name = "Mac Copy";
+  };
+
+  Mac_Paste: Mac_Paste {
+    compatible = "zmk,behavior-macro";
+    #binding-cells = <0>;
+    bindings = <&kp LG(V)>;
+    display-name = "Mac Paste";
+  };
+
+  Mac_Undo: Mac_Undo {
+    compatible = "zmk,behavior-macro";
+    #binding-cells = <0>;
+    bindings = <&kp LG(Z)>;
+    display-name = "Mac Undo";
+  };
+
+  Mac_Select_All: Mac_SelAll {
+    compatible = "zmk,behavior-macro";
+    #binding-cells = <0>;
+    bindings = <&kp LG(A)>;
+    display-name = "Mac Select All";
+  };
+
+  Mac_Mission_Control: Mac_ShowAW {
+    compatible = "zmk,behavior-macro";
+    #binding-cells = <0>;
+    bindings = <&kp LC(UP_ARROW)>;
+    display-name = "Mac Show All Windows";
+  };
+
+  Mac_Snip_Tool: Mac_Snip {
+    compatible = "zmk,behavior-macro";
+    #binding-cells = <0>;
+    bindings = <&kp LC(LG(LS(NUMBER_4)))>;
+    display-name = "Mac Screen Snip";
+  };
+
+  Win_Close_Program: Win_Close_Program {
+    compatible = "zmk,behavior-macro";
+    #binding-cells = <0>;
+    bindings = <&kp LA(F4)>;
+    display-name = "Windows Close";
+  };
+
+  Win_Settings_Menu: Win_Settings_Menu {
+    compatible = "zmk,behavior-macro";
+    #binding-cells = <0>;
+    bindings = <&kp LG(I)>;
+    display-name = "Windows Settings";
+  };
+
+  Win_Lock_PC: Win_Lock_PC {
+    compatible = "zmk,behavior-macro";
+    #binding-cells = <0>;
+    bindings = <&kp LG(L)>;
+    display-name = "Windows Lock";
+  };
+
+  Win_Tile_Left: Win_Tile_Left {
+    compatible = "zmk,behavior-macro";
+    #binding-cells = <0>;
+    bindings = <&kp LG(LEFT)>;
+    display-name = "Windows Tile Left";
+  };
+
+  Win_Tile_Up: Win_Tile_Up {
+    compatible = "zmk,behavior-macro";
+    #binding-cells = <0>;
+    bindings = <&kp LG(UP_ARROW)>;
+    display-name = "Windows Tile Up";
+  };
+
+  Win_Tile_Down: Win_Tile_Down {
+    compatible = "zmk,behavior-macro";
+    #binding-cells = <0>;
+    bindings = <&kp LG(DOWN)>;
+    display-name = "Windows Tile Down";
+  };
+
+  Win_Tile_Right: Win_Tile_Right {
+    compatible = "zmk,behavior-macro";
+    #binding-cells = <0>;
+    bindings = <&kp LG(RIGHT)>;
+    display-name = "Windows Tile Right";
+  };
+
+  Mac_Spotlight_Search: Mac_Spotlight_Search {
+    compatible = "zmk,behavior-macro";
+    #binding-cells = <0>;
+    bindings = <&kp LG(SPACE)>;
+    display-name = "Mac Spotlight Search";
+  };
+
+  Mac_Close_Program: Mac_Close_Program {
+    compatible = "zmk,behavior-macro";
+    #binding-cells = <0>;
+    bindings = <&kp LG(Q)>;
+    display-name = "Mac Close Program";
+  };
+
+  Mac_Strike_Through_Text: Mac_Strike_Through_Text {
+    compatible = "zmk,behavior-macro";
+    #binding-cells = <0>;
+    bindings = <&kp LG(LS(X))>;
+    display-name = "Mac Strikethrough Text";
+  };
+
+  Double_Click: Double_Click {
+    compatible = "zmk,behavior-macro";
+    #binding-cells = <0>;
+    bindings = <&mkp MB1 &mkp MB1>;
+    display-name = "Double Click";
+  };

--- a/config/tomzbench.dtsi
+++ b/config/tomzbench.dtsi
@@ -1,0 +1,74 @@
+
+lsft_sqt: lsft_sqt {
+        label = "lsft_sqt";
+        compatible = "zmk,behavior-mod-morph";
+        #binding-cells = <0>;
+        bindings = <&kp LSFT>, <&kp SQT>;
+        mods = <(MOD_RSFT)>;
+};
+
+rsft_dqt: rsft_dqt {
+        label = "rsft_sqt";
+        compatible = "zmk,behavior-mod-morph";
+        #binding-cells = <0>;
+        bindings = <&kp RSFT>, <&kp DQT>;
+        mods = <(MOD_LSFT)>;
+};        
+
+grave_tilde: grave_tilde {
+        label = "grave_tilde";
+        compatible = "zmk,behavior-mod-morph";
+        #binding-cells = <0>;
+        bindings = <&kp GRAVE>, <&kp TILDE>;
+        mods = <(MOD_RSFT)>;
+};
+
+/* Similar to mo_fast_hold but pairs with CTRL/SHIFTS like keys
+   instead of layers */
+kp_fast_hold: kp_fast_hold {
+        label = "kp_fast_hold";
+        compatible = "zmk,behavior-hold-tap";
+        #binding-cells = <2>;
+        quick-tap-ms = <200>;       
+        flavor = "hold-preferred";
+        tapping-term-ms = <200>;
+        bindings = <&kp>, <&kp>;
+};
+
+/*  Assuming slow key, rolling will hold.  If you want the key
+    press you will release it assertively before next press.
+    This is good for ESC/TAB/ENTER key, with fast layers. */
+mo_fast_hold: mo_fast_hold {
+        label = "mo_fast_hold";
+        compatible = "zmk,behavior-hold-tap";
+        #binding-cells = <2>;
+        quick-tap-ms = <200>;       
+        flavor = "hold-preferred";
+        tapping-term-ms = <200>;
+        bindings = <&mo>, <&kp>;
+};
+
+/* Similar to kp_slow_hold but pairs with Layers instead keys */
+mo_slow_hold: mo_slow_hold {
+        label = "mo_slow_hold";
+        compatible = "zmk,behavior-hold-tap";
+        #binding-cells = <2>;
+        quick-tap-ms = <200>;       
+        flavor = "tap-preferred";
+        tapping-term-ms = <250>;
+        bindings = <&mo>, <&kp>;
+};
+
+/*  Assuming a fast key, rolling taps. If you want hold you will
+    be explicit. This is good for SPACE bar which will roll 
+    a lot. But not good to pair with a layer */
+kp_slow_hold: kp_slow_hold {
+        label = "kp_slow_hold";
+        compatible = "zmk,behavior-hold-tap";
+        #binding-cells = <2>;
+        quick-tap-ms = <200>;       
+        flavor = "tap-preferred";
+        tapping-term-ms = <250>;
+        bindings = <&kp>, <&kp>;
+};
+         

--- a/config/totem.conf
+++ b/config/totem.conf
@@ -8,4 +8,10 @@ CONFIG_ZMK_IDLE_SLEEP_TIMEOUT=900000
 CONFIG_ZMK_POINTING=y
 # comment out below to reduce battery use.  This is increased for users with bad bluetooth
 CONFIG_BT_CTLR_TX_PWR_PLUS_8=y
-#CONFIG_ZMK_STUDIO=y
+
+# Live keymap editing over USB/BLE (ZMK Studio). Unlock with &studio_unlock on the SYS layer.
+CONFIG_ZMK_STUDIO=y
+
+# Report BOTH halves' battery levels to the host (peripheral = right half).
+CONFIG_ZMK_SPLIT_BLE_CENTRAL_BATTERY_LEVEL_FETCHING=y
+CONFIG_ZMK_SPLIT_BLE_CENTRAL_BATTERY_LEVEL_PROXY=y

--- a/config/totem.keymap
+++ b/config/totem.keymap
@@ -1,165 +1,142 @@
-//
-//                                                        ▀▀▀▀▀     ▀▀▀▀▀          ▀▀█▀▀
-//                                                        ▄▀▀▀▄  ▄  ▄▀▀▀▄  ▄  ▄▀▀▀▄  █  ▄▀▀▀▄
-//                                                        █   █  █  █   █  █  █   █  █  █   █
-//                                                         ▀▀▀   █   ▀▀▀   █   ▀▀▀   ▀   ▀▀▀
-//                                                               █      ▄▄▄█▄▄▄    █   █  
-//                                                               ▀      █  █  █     █▄█
-//                                                             ▀▀▀▀▀    █  █  █      ▀
-//                                                                      ▀  ▀  ▀
-//
-// ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+/*
+ * KBH Totem (38-key) — port of tomzbench's Kinesis Adv360 keymap to ZMK.
+ *
+ * Philosophy (carried over from the Adv360 config):
+ *   - Thumb mods, NOT home-row mods. Home row stays pure letters -> no
+ *     roll misfires. Mods live on the thumbs (GUI/CTRL) and the pinkies.
+ *   - Shift  = mod-morph on the row-3 outer pinkies (tap = ' / ").
+ *   - Alt    = hold-tap on Z and / (tap-preferred, so typing never misfires).
+ *   - Layers: hold an inner thumb for NUM / SYM. Hold BOTH -> SYS (tri-layer).
+ *   - Brackets live on the thumbs of the OPPOSITE hand from the layer hold:
+ *       NUM (held by right thumb) -> [ ] on the LEFT thumbs
+ *       SYM (held by left  thumb) -> { } on the RIGHT thumbs
+ *
+ * Behaviors (kp_fast_hold / kp_slow_hold / mo_fast_hold) and the shift
+ * mod-morphs come straight from tomzbench.dtsi. Macros come from macros.dtsi
+ * (defined but unbound, available to map later).
+ */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/bt.h>
 #include <dt-bindings/zmk/keys.h>
-#include <dt-bindings/zmk/outputs.h>
+#include <dt-bindings/zmk/bt.h>
 #include <dt-bindings/zmk/pointing.h>
 
 #define BASE 0
-#define NAV  1
+#define NUM  1
 #define SYM  2
-#define ADJ  3
+#define SYS  3
 
-&mt {
-    quick-tap-ms = <100>;
-    global-quick-tap;
-    flavor = "tap-preferred";
-    tapping-term-ms = <170>;
-};
+/* Thumb dual-role keys (1:1 with the Adv360 thumb cluster) */
+#define LGUI_ESC    &kp_fast_hold LGUI  ESC
+#define LCTRL_SPACE &kp_slow_hold LCTRL SPACE
+#define SYM_TAB     &mo_fast_hold SYM   TAB
+#define NUM_BSPC    &mo_fast_hold NUM   BSPC
+#define RCTRL_ENTER &kp_fast_hold RCTRL ENTER
+#define RGUI_DEL    &kp_fast_hold RGUI  DELETE
 
 / {
-    combos {
-        compatible = "zmk,combos";
+    behaviors {
+        #include "macros.dtsi"
+        #include "tomzbench.dtsi"
 
-        combo_esc {
-            timeout-ms = <50>;
-            key-positions = <0 1>;
-            bindings = <&kp ESC>;
+        /* Pinky alt: hold = mod, tap = letter. tap-preferred = no misfire
+           during fast typing; Alt only fires on a deliberate hold. */
+        pmt: pinky_mod_tap {
+            compatible = "zmk,behavior-hold-tap";
+            label = "PINKY_MOD_TAP";
+            #binding-cells = <2>;
+            flavor = "tap-preferred";
+            tapping-term-ms = <200>;
+            quick-tap-ms = <175>;
+            bindings = <&kp>, <&kp>;
         };
     };
 
-    macros {
-        gif: gif {
-            label = "giphy";
-            compatible = "zmk,behavior-macro";
-            #binding-cells = <0>;
-            bindings =
-                <&macro_press>,
-                <&kp LSHFT>,
-                <&macro_tap>,
-                <&kp N2>,
-                <&macro_release>,
-                <&kp LSHFT>,
-                <&macro_tap>,
-                <&kp G &kp I &kp F>;
+    conditional_layers {
+        compatible = "zmk,conditional-layers";
+        /* hold NUM + SYM (both inner thumbs) -> SYS */
+        tri_sys {
+            if-layers = <NUM SYM>;
+            then-layer = <SYS>;
         };
     };
 
     keymap {
         compatible = "zmk,keymap";
 
-        // ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
-
+        /*
+         * ╭─────────────────────────────╮ ╭─────────────────────────────╮
+         * │  Q    W    E    R    T       │ │       Y    U    I    O    P  │
+         * │  A    S    D    F    G       │ │       H    J    K    L    ;  │
+         * │ '"⇧ Z⌥  X    C    V    B     │ │     N    M    ,    .  /⌥ "'⇧ │
+         * ╰──────────╮ GUI  CTL  SYM     │ │     NUM  CTL  GUI ╭──────────╯
+         *            ╰ /esc /spc /tab    │ │     /bsp /ent /del╯
+         */
         base_layer {
-            // ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-
-            label = "BASE";
-
-            // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-            //             ┏━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┓   ┏━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┓
-            //             ┃     Q     ┃     W     ┃     F     ┃     P     ┃     G     ┃   ┃     J     ┃     L     ┃     U     ┃     Y     ┃     ;     ┃
-            //             ┣━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━┫   ┣━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━┫
-            //             ┃     A     ┃     R     ┃     S     ┃     T     ┃     D     ┃   ┃     H     ┃     N     ┃     E     ┃     I     ┃     O     ┃
-            // ┏━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━┫   ┣━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━┓
-            // ┃           ┃     Z     ┃     X     ┃     C     ┃     V     ┃     B     ┃   ┃     K     ┃     M     ┃     ,     ┃     .     ┃     /     ┃           ┃
-            // ┗━━━━━━━━━━━┻━━━━━━━━━━━┻━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━┫   ┣━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━┻━━━━━━━━━━━┻━━━━━━━━━━━┛
-            //                                     ┃           ┃    TAB    ┃    SPC    ┃   ┃   ENTER   ┃   BSPC    ┃           ┃
-            //                                     ┗━━━━━━━━━━━┻━━━━━━━━━━━┻━━━━━━━━━━━┛   ┗━━━━━━━━━━━┻━━━━━━━━━━━┻━━━━━━━━━━━┛
-
+            display-name = "BASE";
             bindings = <
-                  &kp Q       &kp W       &kp E         &kp R        &kp T            &kp Y        &kp U        &kp I          &kp O       &kp P
-                  &mt LGUI A  &mt LALT S  &mt LCTRL D   &mt LSHFT F  &kp G            &kp H        &mt RSHFT J  &mt RCTRL K    &mt RALT L  &mt RGUI SEMI
-&kp LEFT_CONTROL  &kp Z       &kp X       &kp C         &kp V        &kp B            &kp N        &kp M        &kp COMMA      &kp DOT     &kp SLASH       &kp APOS
-                                          &kp LEFT_GUI  &kp TAB      &lt NAV SPACE    &lt SYM RET  &kp BSPC     &kp LEFT_ALT
+  &kp Q       &kp W        &kp E    &kp R    &kp T          &kp Y    &kp U    &kp I      &kp O    &kp P
+  &kp A       &kp S        &kp D    &kp F    &kp G          &kp H    &kp J    &kp K      &kp L    &kp SEMI
+  &lsft_sqt &pmt LALT Z &kp X &kp C &kp V &kp B            &kp N &kp M &kp COMMA &kp DOT &pmt RALT FSLH &rsft_dqt
+                          LGUI_ESC LCTRL_SPACE SYM_TAB      NUM_BSPC RCTRL_ENTER RGUI_DEL
             >;
         };
 
-        // ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
-
-        nav_layer {
-            // ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-
-            label = "NAVI";
-
-            // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-            //             ┏━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┓   ┏━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┓
-            //             ┃           ┃           ┃     UP    ┃           ┃     {     ┃   ┃     }     ┃     7     ┃     8     ┃     9     ┃     +     ┃
-            //             ┣━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━┫   ┣━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━┫
-            //             ┃   SHIFT   ┃   LEFT    ┃    DOWN   ┃   RIGHT   ┃     [     ┃   ┃     ]     ┃     4     ┃     5     ┃     6     ┃     -     ┃
-            // ┏━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━┫   ┣━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━┓
-            // ┃           ┃           ┃   P UP    ┃  C LOCK   ┃  P DOWN   ┃     (     ┃   ┃     )     ┃     1     ┃     2     ┃     3     ┃     *     ┃           ┃
-            // ┗━━━━━━━━━━━┻━━━━━━━━━━━┻━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━┫   ┣━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━┻━━━━━━━━━━━┻━━━━━━━━━━━┛
-            //                                     ┃           ┃    TAB    ┃    SPC    ┃   ┃    DEL    ┃     0     ┃           ┃
-            //                                     ┗━━━━━━━━━━━┻━━━━━━━━━━━┻━━━━━━━━━━━┛   ┗━━━━━━━━━━━┻━━━━━━━━━━━┻━━━━━━━━━━━┛
-
+        /*
+         * NUM — hold right inner thumb. Numbers on the LEFT hand, mods +
+         *       arrows on the RIGHT (so Ctrl+2 etc. work; arrows sit under
+         *       the home row). [ ] on the left thumbs.
+         * ╭─────────────────────────────╮ ╭─────────────────────────────╮
+         * │  +    7    8    9    0       │ │                             │
+         * │  -    1    2    3    =       │ │       :   GUI  CTL  ALT      │
+         * │      *    4    5    6    \   │ │         ←    ↓    ↑    →      │
+         * ╰──────────╮  [    ]          │ │     (num)        ╭──────────╯
+         */
+        num_layer {
+            display-name = "NUM";
             bindings = <
-            &kp ESC    &bt BT_CLR  &kp UP    &kp EQUAL  &kp LBRC    &kp RBRC  &kp N7        &kp N8        &kp N9        &kp KP_PLUS
-            &kp LSHFT  &kp LEFT    &kp DOWN  &kp RIGHT  &kp LBKT    &kp RBKT  &kp NUMBER_4  &kp N5        &kp NUMBER_6  &kp KP_MINUS
-&caps_word  &kp DEL    &kp PG_UP   &kp CAPS  &kp PG_DN  &kp LPAR    &kp RPAR  &kp NUMBER_1  &kp NUMBER_2  &kp NUMBER_3  &kp KP_MULTIPLY  &trans
-                                   &trans    &trans     &trans      &mo ADJ   &kp KP_N0     &trans
+  &kp PLUS    &kp N7       &kp N8   &kp N9   &kp N0         &trans     &trans   &trans    &trans    &trans
+  &kp MINUS   &kp N1       &kp N2   &kp N3   &kp EQUAL      &kp COLON  &kp RGUI &kp RCTRL &kp RALT  &trans
+  &trans  &kp ASTRK &kp N4 &kp N5 &kp N6 &kp BSLH          &trans  &kp LEFT &kp DOWN &kp UP &kp RIGHT  &trans
+                          &kp LBKT &kp RBKT &trans          &trans     &trans   &trans
             >;
         };
 
-        // ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
-
-        sim_layer {
-            // ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-
-            label = "SYM";
-
-            // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-            //             ┏━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┓   ┏━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┓
-            //             ┃     !     ┃     @     ┃     #     ┃     $     ┃     %     ┃   ┃     ˆ     ┃     &     ┃     Ü     ┃     '     ┃     "     ┃
-            //             ┣━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━┫   ┣━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━┫
-            //             ┃     Ä     ┃           ┃    SZ     ┃           ┃           ┃   ┃   MUTE    ┃   YEN     ┃   EURO    ┃  POUND    ┃     Ö     ┃
-            // ┏━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━┫   ┣━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━┓
-            // ┃           ┃  EMAIL1   ┃  EMAIL2   ┃           ┃           ┃           ┃   ┃   VOL-    ┃   VOL+    ┃   LAST    ┃   NEXT    ┃     \     ┃           ┃
-            // ┗━━━━━━━━━━━┻━━━━━━━━━━━┻━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━┫   ┣━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━┻━━━━━━━━━━━┻━━━━━━━━━━━┛
-            //                                     ┃           ┃    GIF    ┃    ADJ    ┃   ┃           ┃           ┃           ┃
-            //                                     ┗━━━━━━━━━━━┻━━━━━━━━━━━┻━━━━━━━━━━━┛   ┗━━━━━━━━━━━┻━━━━━━━━━━━┻━━━━━━━━━━━┛
-
+        /*
+         * SYM — hold left inner thumb. Symbols on the RIGHT hand, left hand
+         *       transparent (the hold hand). { } on the right thumbs.
+         * ╭─────────────────────────────╮ ╭─────────────────────────────╮
+         * │                             │ │   ~    &    *    (    )      │
+         * │                             │ │   _    !    @    #    +      │
+         * │                             │ │     `    $    %    ^    |    │
+         * ╰──────────╮      (sym)       │ │              {    } ╭───────╯
+         */
+        sym_layer {
+            display-name = "SYM";
             bindings = <
-        &kp EXCL     &kp AT       &kp HASH   &kp DLLR  &kp PRCNT    &kp CARET  &kp AMPS      &kp RA(U)             &kp SQT                &kp DQT
-        &kp RA(A)    &trans       &kp RA(S)  &trans    &trans       &kp MINUS  &kp EQUAL     &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp RA(O)
-&trans  &kp RA(F18)  &kp RA(F19)  &trans     &trans    &trans       &kp GRAVE  &kp ASTERISK  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp BSLH   &trans
-                                  &trans     &gif      &mo ADJ      &trans     &kp C_PP      &trans
+  &trans      &trans       &trans   &trans   &trans         &kp TILDE  &kp AMPS   &kp ASTRK   &kp LPAR  &kp RPAR
+  &trans      &trans       &trans   &trans   &trans         &kp UNDER  &kp EXCL   &kp AT      &kp HASH  &kp PLUS
+  &trans  &trans &trans &trans &trans &trans               &kp GRAVE &kp DOLLAR &kp PERCENT &kp CARET &kp PIPE  &trans
+                          &trans   &trans   &trans          &trans     &kp LBRC   &kp RBRC
             >;
         };
 
-        // ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
-
-        adjust_layer {
-            // ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-
-            label = "ADJ";
-
-            // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
-            //             ┏━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┓   ┏━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┓
-            //             ┃   RESET   ┃ BT CLEAR  ┃  OUT TOG  ┃           ┃           ┃   ┃           ┃    F7     ┃    F8     ┃    F9     ┃    F12    ┃
-            //             ┣━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━┫   ┣━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━┫
-            //             ┃ BOOTLOAD  ┃ BT NEXT   ┃           ┃           ┃           ┃   ┃           ┃    F4     ┃    F5     ┃    F6     ┃    F11    ┃
-            // ┏━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━┫   ┣━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━┓
-            // ┃           ┃           ┃ BT PREV   ┃           ┃           ┃           ┃   ┃           ┃    F1     ┃    F2     ┃    F3     ┃    F10    ┃           ┃
-            // ┗━━━━━━━━━━━┻━━━━━━━━━━━┻━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━┫   ┣━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━╋━━━━━━━━━━━┻━━━━━━━━━━━┻━━━━━━━━━━━┛
-            //                                     ┃           ┃           ┃           ┃   ┃           ┃           ┃           ┃
-            //                                     ┗━━━━━━━━━━━┻━━━━━━━━━━━┻━━━━━━━━━━━┛   ┗━━━━━━━━━━━┻━━━━━━━━━━━┻━━━━━━━━━━━┛
-
+        /*
+         * SYS — hold NUM + SYM together. F-keys on the LEFT, mirroring the
+         *       digit positions (F1 where 1 is...). BT + bootloader on RIGHT.
+         * ╭─────────────────────────────╮ ╭─────────────────────────────╮
+         * │ F11   F7   F8   F9  F10      │ │  BOOT                       │
+         * │ F12   F1   F2   F3           │ │ BTclr BT0  BT1  BT2  BT3     │
+         * │      F4   F5   F6            │ │     BT4 BTnxt               │
+         * ╰──────────╮                   │ │                  ╭──────────╯
+         */
+        sys_layer {
+            display-name = "SYS";
             bindings = <
-              &sys_reset    &trans        &out OUT_TOG  &trans        &trans            &trans  &kp F7  &kp F8  &kp F9  &kp F12
-              &bootloader   &trans        &trans        &trans        &trans            &trans  &kp F4  &kp F5  &kp F6  &kp F11
-&bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &bt BT_CLR_ALL    &trans  &kp F1  &kp F2  &kp F3  &kp F10  &trans
-                                          &trans        &trans        &trans            &trans  &trans  &trans
+  &kp F11     &kp F7       &kp F8   &kp F9   &kp F10        &bootloader &trans     &trans     &trans     &trans
+  &kp F12     &kp F1       &kp F2   &kp F3   &trans         &bt BT_CLR &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3
+  &trans  &trans &kp F4 &kp F5 &kp F6 &trans               &bt BT_SEL 4 &bt BT_NXT &trans &trans &trans  &trans
+                          &trans   &trans   &trans          &trans     &trans     &trans
             >;
         };
     };

--- a/config/totem.keymap
+++ b/config/totem.keymap
@@ -19,6 +19,7 @@
 #include <behaviors.dtsi>
 #include <dt-bindings/zmk/keys.h>
 #include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/outputs.h>
 #include <dt-bindings/zmk/pointing.h>
 
 #define BASE 0
@@ -122,20 +123,20 @@
         };
 
         /*
-         * SYS — hold NUM + SYM together. F-keys on the LEFT, mirroring the
-         *       digit positions (F1 where 1 is...). BT + bootloader on RIGHT.
+         * SYS — hold NUM + SYM together. F-keys on the LEFT (mirroring the
+         *       NUM digits). System/BT on the RIGHT.
          * ╭─────────────────────────────╮ ╭─────────────────────────────╮
-         * │ F11   F7   F8   F9  F10      │ │  BOOT                       │
+         * │ F11   F7   F8   F9  F10      │ │ BOOT OUTtog STUDIO          │
          * │ F12   F1   F2   F3           │ │ BTclr BT0  BT1  BT2  BT3     │
-         * │      F4   F5   F6            │ │     BT4 BTnxt               │
+         * │      F4   F5   F6            │ │   BT4 BTnxt BTclrA          │
          * ╰──────────╮                   │ │                  ╭──────────╯
          */
         sys_layer {
             display-name = "SYS";
             bindings = <
-  &kp F11     &kp F7       &kp F8   &kp F9   &kp F10        &bootloader &trans     &trans     &trans     &trans
+  &kp F11     &kp F7       &kp F8   &kp F9   &kp F10        &bootloader &out OUT_TOG &studio_unlock &trans &trans
   &kp F12     &kp F1       &kp F2   &kp F3   &trans         &bt BT_CLR &bt BT_SEL 0 &bt BT_SEL 1 &bt BT_SEL 2 &bt BT_SEL 3
-  &trans  &trans &kp F4 &kp F5 &kp F6 &trans               &bt BT_SEL 4 &bt BT_NXT &trans &trans &trans  &trans
+  &trans  &trans &kp F4 &kp F5 &kp F6 &trans               &bt BT_SEL 4 &bt BT_NXT &bt BT_CLR_ALL &trans &trans  &trans
                           &trans   &trans   &trans          &trans     &trans     &trans
             >;
         };

--- a/config/totem.keymap
+++ b/config/totem.keymap
@@ -55,7 +55,7 @@
 
     conditional_layers {
         compatible = "zmk,conditional-layers";
-        /* hold NUM + SYM (both inner thumbs) -> SYS */
+        /* hold NUM + SYM (squeeze both middle thumbs) -> SYS */
         tri_sys {
             if-layers = <NUM SYM>;
             then-layer = <SYS>;
@@ -70,8 +70,9 @@
          * │  Q    W    E    R    T       │ │       Y    U    I    O    P  │
          * │  A    S    D    F    G       │ │       H    J    K    L    ;  │
          * │ '"⇧ Z⌥  X    C    V    B     │ │     N    M    ,    .  /⌥ "'⇧ │
-         * ╰──────────╮ GUI  CTL  SYM     │ │     NUM  CTL  GUI ╭──────────╯
-         *            ╰ /esc /spc /tab    │ │     /bsp /ent /del╯
+         * ╰──────────╮ GUI  SYM  CTL     │ │     CTL  NUM  GUI ╭──────────╯
+         *            ╰ /esc /tab /spc    │ │     /ent /bsp /del╯
+         *   (SYS = squeeze both middle thumbs: SYM + NUM)
          */
         base_layer {
             display-name = "BASE";
@@ -79,19 +80,19 @@
   &kp Q       &kp W        &kp E    &kp R    &kp T          &kp Y    &kp U    &kp I      &kp O    &kp P
   &kp A       &kp S        &kp D    &kp F    &kp G          &kp H    &kp J    &kp K      &kp L    &kp SEMI
   &lsft_sqt &pmt LALT Z &kp X &kp C &kp V &kp B            &kp N &kp M &kp COMMA &kp DOT &pmt RALT FSLH &rsft_dqt
-                          LGUI_ESC LCTRL_SPACE SYM_TAB      NUM_BSPC RCTRL_ENTER RGUI_DEL
+                          LGUI_ESC SYM_TAB LCTRL_SPACE      RCTRL_ENTER NUM_BSPC RGUI_DEL
             >;
         };
 
         /*
-         * NUM — hold right inner thumb. Numbers on the LEFT hand, mods +
-         *       arrows on the RIGHT (so Ctrl+2 etc. work; arrows sit under
-         *       the home row). [ ] on the left thumbs.
+         * NUM — hold right-MIDDLE thumb. Numbers LEFT, mods+arrows RIGHT
+         *       (Ctrl+2 etc. work; arrows under the home row). [ ] on the
+         *       left middle+center; the middle also holds SYM (tap-pref) -> SYS.
          * ╭─────────────────────────────╮ ╭─────────────────────────────╮
          * │  +    7    8    9    0       │ │                             │
          * │  -    1    2    3    =       │ │       :   GUI  CTL  ALT      │
          * │      *    4    5    6    \   │ │         ←    ↓    ↑    →      │
-         * ╰──────────╮  [    ]          │ │     (num)        ╭──────────╯
+         * ╰──────────╮  ·  [⇧SYM ]      │ │    (num)         ╭──────────╯
          */
         num_layer {
             display-name = "NUM";
@@ -99,18 +100,19 @@
   &kp PLUS    &kp N7       &kp N8   &kp N9   &kp N0         &trans     &trans   &trans    &trans    &trans
   &kp MINUS   &kp N1       &kp N2   &kp N3   &kp EQUAL      &kp COLON  &kp RGUI &kp RCTRL &kp RALT  &trans
   &trans  &kp ASTRK &kp N4 &kp N5 &kp N6 &kp BSLH          &trans  &kp LEFT &kp DOWN &kp UP &kp RIGHT  &trans
-                          &kp LBKT &kp RBKT &trans          &trans     &trans   &trans
+                          &trans &mo_slow_hold SYM LBKT &kp RBKT          &trans &trans &trans
             >;
         };
 
         /*
-         * SYM — hold left inner thumb. Symbols on the RIGHT hand, left hand
-         *       transparent (the hold hand). { } on the right thumbs.
+         * SYM — hold left-MIDDLE thumb. Symbols on the RIGHT hand, left
+         *       transparent. { } on the right center+middle; the middle
+         *       also holds NUM (tap-pref) -> SYS.
          * ╭─────────────────────────────╮ ╭─────────────────────────────╮
          * │                             │ │   ~    &    *    (    )      │
          * │                             │ │   _    !    @    #    +      │
          * │                             │ │     `    $    %    ^    |    │
-         * ╰──────────╮      (sym)       │ │              {    } ╭───────╯
+         * ╰──────────╮      (sym)       │ │       {  ]⇧NUM ·  ╭────────╯
          */
         sym_layer {
             display-name = "SYM";
@@ -118,7 +120,7 @@
   &trans      &trans       &trans   &trans   &trans         &kp TILDE  &kp AMPS   &kp ASTRK   &kp LPAR  &kp RPAR
   &trans      &trans       &trans   &trans   &trans         &kp UNDER  &kp EXCL   &kp AT      &kp HASH  &kp PLUS
   &trans  &trans &trans &trans &trans &trans               &kp GRAVE &kp DOLLAR &kp PERCENT &kp CARET &kp PIPE  &trans
-                          &trans   &trans   &trans          &trans     &kp LBRC   &kp RBRC
+                          &trans &trans &trans          &kp LBRC &mo_slow_hold NUM RBRC &trans
             >;
         };
 


### PR DESCRIPTION
Replace the keymap with a 4-layer port of the Kinesis Adv360 "tomzbench" config: thumb mods (no home-row mods), shift mod-morphs on the outer pinkies, Alt as a tap-preferred hold on Z and /, and a NUM+SYM tri-layer for SYS. Brackets/braces ride the opposite-hand thumbs. Copy the source behaviors (tomzbench.dtsi) and macros (macros.dtsi) in-tree so the repo is self-contained. Rewrite CLAUDE.md as a forward-looking design doc.